### PR TITLE
Added cursor metric items, eg: db.serverStatus().metrics.cursor mainly to fix mongos cursor metrics

### DIFF
--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -397,7 +397,7 @@ type CursorStats struct {
 // Export exports the cursor stats.
 func (cursorStats *CursorStats) Export(ch chan<- prometheus.Metric) {
 	metricsCursorTimedOutTotal.Set(cursorStats.TimedOut)
-	metricsCursorOpen.WithLabelValues("noTimeout").Set(cursorStats.Open.NoTimeout)
+	metricsCursorOpen.WithLabelValues("timeout").Set(cursorStats.Open.NoTimeout)
 	metricsCursorOpen.WithLabelValues("pinned").Set(cursorStats.Open.Pinned)
 	metricsCursorOpen.WithLabelValues("total").Set(cursorStats.Open.Total)
 }

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -397,7 +397,7 @@ type CursorStats struct {
 // Export exports the cursor stats.
 func (cursorStats *CursorStats) Export(ch chan<- prometheus.Metric) {
 	metricsCursorTimedOutTotal.Set(cursorStats.TimedOut)
-	metricsCursorOpen.WithLabelValues("timedout").Set(cursorStats.Open.NoTimeout)
+	metricsCursorOpen.WithLabelValues("timed_out").Set(cursorStats.Open.NoTimeout)
 	metricsCursorOpen.WithLabelValues("pinned").Set(cursorStats.Open.Pinned)
 	metricsCursorOpen.WithLabelValues("total").Set(cursorStats.Open.Total)
 }

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -397,7 +397,7 @@ type CursorStats struct {
 // Export exports the cursor stats.
 func (cursorStats *CursorStats) Export(ch chan<- prometheus.Metric) {
 	metricsCursorTimedOutTotal.Set(cursorStats.TimedOut)
-	metricsCursorOpen.WithLabelValues("timeout").Set(cursorStats.Open.NoTimeout)
+	metricsCursorOpen.WithLabelValues("timedout").Set(cursorStats.Open.NoTimeout)
 	metricsCursorOpen.WithLabelValues("pinned").Set(cursorStats.Open.Pinned)
 	metricsCursorOpen.WithLabelValues("total").Set(cursorStats.Open.Total)
 }


### PR DESCRIPTION
Due to deprecation I am noticing that mongos processes in (at least) MongoDB 3.0.8 no longer return cursor metrics at 'db.serverStatus().cursors'. The new location for these cursor metrics is 'db.serverStatus().metrics.cursor', so I've added this to the metrics.go file.

At a later date, the original location for cursors should probably be phased out as it will no longer exist in future MongoDB versions.

Example:

`[tim@centos7 collector]$ mongo --port=27018
MongoDB shell version: 3.0.8
connecting to: 127.0.0.1:27018/test
mongos> db.serverStatus().cursors        <==== NO OUTPUT HERE
mongos> db.serverStatus().metrics.cursor
{
	"open" : {
		"multiTarget" : NumberLong(0),
		"singleTarget" : NumberLong(0),
		"total" : NumberLong(0)
	}
}
`