### PR TITLE
Close only with not-nil session

### DIFF
--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -40,8 +40,8 @@ func (exporter *MongodbCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects all mongodb's metrics.
 func (exporter *MongodbCollector) Collect(ch chan<- prometheus.Metric) {
 	mongoSess := shared.MongoSession(exporter.Opts.URI)
-	defer mongoSess.Close()
 	if mongoSess != nil {
+		defer mongoSess.Close()
 		glog.Info("Collecting Server Status")
 		exporter.collectServerStatus(mongoSess, ch)
 		glog.Info("Collecting ReplSet Status")


### PR DESCRIPTION
If the connection to MongoDB can't be established or is lost Collect calls Close on a potentially nil session:

```
E0524 07:01:17.035316 14230 connection.go:27] Cannot connect to server using url mongodb://localhost:27017: no reachable servers
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x25cf4d]

goroutine 24 [running]:
panic(0x49a240, 0xc82000a1f0)
	/usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:481 +0x3e6
gopkg.in/mgo%2ev2.(*Session).Close(0x0)
	/Users/zerok/go/src/gopkg.in/mgo.v2/session.go:1557 +0x13d
github.com/dcu/mongodb_exporter/collector.(*MongodbCollector).Collect(0xc82011cc20, 0xc8200fe960)
	/Users/zerok/go/src/github.com/dcu/mongodb_exporter/collector/mongodb_collector.go:50 +0x259
github.com/prometheus/client_golang/prometheus.(*registry).writePB.func2(0xc82000afe0, 0xc8200fe960, 0xc04ce8, 0xc82011cc20)
	/Users/zerok/go/src/github.com/prometheus/client_golang/prometheus/registry.go:418 +0x58
created by github.com/prometheus/client_golang/prometheus.(*registry).writePB
	/Users/zerok/go/src/github.com/prometheus/client_golang/prometheus/registry.go:419 +0x34d
```

With this change the connection is only closed if the session is there.