### PR TITLE
healthcheck endpoint

### DIFF
--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -91,6 +91,15 @@ func startWebServer() {
 	registerCollector()
 
 	http.Handle(*metricsPathFlag, handler)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+<head><title>MongoDB Exporter</title></head>
+<body>
+<h1>MongoDB Exporter</h1>
+<p><a href='` + *metricsPathFlag + `'>Metrics</a></p>
+</body>
+</html>`))
+	})
 
 	server := &http.Server{
 		Addr:     *listenAddressFlag,


### PR DESCRIPTION
Fixes #30 

some of the other prom exporters follow this pattern

this provides an endpoint to use for health checks w/o having to hit /metrics