### PR TITLE
Fixed casing of Tls->TLS, repairs build

### DIFF
--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -15,10 +15,10 @@ var (
 // MongodbCollectorOpts is the options of the mongodb collector.
 type MongodbCollectorOpts struct {
 	URI                    string
-	TlsCertificateFile     string
-	TlsPrivateKeyFile      string
-	TlsCaFile              string
-	TlsHostnameValidation  bool
+	TLSCertificateFile     string
+	TLSPrivateKeyFile      string
+	TLSCaFile              string
+	TLSHostnameValidation  bool
 	CollectReplSet         bool
 	CollectOplog           bool
 	CollectDatabaseMetrics bool
@@ -27,10 +27,10 @@ type MongodbCollectorOpts struct {
 func (in MongodbCollectorOpts) toSessionOps() shared.MongoSessionOpts {
 	return shared.MongoSessionOpts{
 		URI:                   in.URI,
-		TlsCertificateFile:    in.TlsCertificateFile,
-		TlsPrivateKeyFile:     in.TlsPrivateKeyFile,
-		TlsCaFile:             in.TlsCaFile,
-		TlsHostnameValidation: in.TlsHostnameValidation,
+		TLSCertificateFile:    in.TLSCertificateFile,
+		TLSPrivateKeyFile:     in.TLSPrivateKeyFile,
+		TLSCaFile:             in.TLSCaFile,
+		TLSHostnameValidation: in.TLSHostnameValidation,
 	}
 }
 

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -115,7 +115,7 @@ func startWebServer() {
 			if err != nil {
 				glog.Fatalf("Couldn't load client CAs from %s. Got: %s", *webTLSClientCa, err)
 			}
-			server.TlsConfig = &tls.Config{
+			server.TLSConfig = &tls.Config{
 				ClientCAs:  certificates,
 				ClientAuth: tls.RequireAndVerifyClientCert,
 			}
@@ -140,10 +140,10 @@ func startWebServer() {
 func registerCollector() {
 	mongodbCollector := collector.NewMongodbCollector(collector.MongodbCollectorOpts{
 		URI:                    *mongodbURIFlag,
-		TlsCertificateFile:     *mongodbTlsCert,
-		TlsPrivateKeyFile:      *mongodbTlsPrivateKey,
-		TlsCaFile:              *mongodbTlsCa,
-		TlsHostnameValidation:  !(*mongodbTlsDisableHostnameValidation),
+		TLSCertificateFile:     *mongodbTLSCert,
+		TLSPrivateKeyFile:      *mongodbTLSPrivateKey,
+		TLSCaFile:              *mongodbTLSCa,
+		TLSHostnameValidation:  !(*mongodbTLSDisableHostnameValidation),
 		CollectOplog:           *mongodbCollectOplog,
 		CollectReplSet:         *mongodbCollectReplSet,
 		CollectDatabaseMetrics: *mongodbCollectDatabaseMetrics,


### PR DESCRIPTION
Currently, the build is broken. I made casing consistent with URI which is all uppercase for an abbrev.