### PR TITLE
[dockerfile] use glide and small improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM       alpine:latest
+FROM       alpine:3.4
 MAINTAINER David Cuadrado <dacuad@facebook.com>
 EXPOSE     9001
 
-ENV  GOPATH /go
-ENV APPPATH $GOPATH/src/github.com/dcu/mongodb_exporter
-COPY . $APPPATH
-RUN apk add --update -t build-deps go git mercurial libc-dev gcc libgcc \
-    && cd $APPPATH && go get -d && go build -o /bin/mongodb_exporter \
+COPY . /go/src/github.com/dcu/mongodb_exporter
+
+RUN apk add --update -t build-deps go git make curl \
+    && export GOPATH=/go && export PATH=$GOPATH/bin:$PATH \
+    && cd $GOPATH/src/github.com/dcu/mongodb_exporter \
+    && mkdir $GOPATH/bin && curl https://glide.sh/get | sh && make deps \
+    && go build -o /bin/mongodb_exporter \
     && apk del --purge build-deps && rm -rf $GOPATH
 
 ENTRYPOINT [ "/bin/mongodb_exporter" ]


### PR DESCRIPTION
Follow-up of #46 to fix the dockerfile build too. It also : 

- uses an explicit tag for alpine instead of latest
- doesn't expose build-time specific env vars
- removes unneeded build deps

Btw, is there an official image on docker hub?