### PR TITLE
fix GetDatabaseStatus and DatabaseStatus.Export for databases without shards

### DIFF
--- a/collector/database_status.go
+++ b/collector/database_status.go
@@ -53,6 +53,7 @@ type DatabaseStatus struct {
 	Shards      map[string]*RawStatus `bson:"raw,omitempty"`
 }
 
+// RawStatus represents stats about a database shard
 type RawStatus struct {
 	Name        string `bson:"db,omitempty"`
 	IndexSize   int    `bson:"indexSize,omitempty"`

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -120,7 +120,7 @@ func (exporter *MongodbCollector) collectDatabaseStatus(session *mgo.Session, ch
 			dbStatus := GetDatabaseStatus(session, db)
 
 			if dbStatus != nil {
-				glog.Info("exporting Database Metrics")
+				glog.Infof("exporting Database Metrics for db=%q", dbStatus.Name)
 				dbStatus.Export(ch)
 			}
 		}


### PR DESCRIPTION
This PR fixes several issues I was having with mongodb_exporter with -mongodb.collect.database enabled. My databases do not have any shards.

* The prometheus library panics with "inconsistent label cardinality". This  is fixed by passing "" for the shard label of the db status gauges when there are no shards.
* In GetDatabaseStatus, the dbStatus object was empty after running the database query, causing failure to collect any statistics. This seems to be caused by embedding the RawStatus type in DatabaseStatus. The object is populated successfully when duplicating the fields in DatabaseStatus rather than embedding the type.
* GetDatabaseStatus passes &dbStatus to session.DB(db).Run, but the type of dbStatus is *DatabaseStatus resulting in a pointer to a pointer to a DatabaseStatus being passed. This PR makes dbStatus a DatabaseStatus, avoiding the extra indirection.