### PR TITLE
shrink Docker image size to ~15MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,7 @@ FROM       alpine:3.4
 MAINTAINER David Cuadrado <dacuad@facebook.com>
 EXPOSE     9001
 
-COPY . /go/src/github.com/dcu/mongodb_exporter
+RUN apk add --update ca-certificates
+COPY release/mongodb_exporter-linux-amd64 /usr/local/bin/mongodb_exporter
 
-RUN apk add --update -t build-deps go git make curl \
-    && export GOPATH=/go && export PATH=$GOPATH/bin:$PATH \
-    && cd $GOPATH/src/github.com/dcu/mongodb_exporter \
-    && mkdir $GOPATH/bin && curl https://glide.sh/get | sh && make deps \
-    && go build -o /bin/mongodb_exporter \
-    && apk del --purge build-deps && rm -rf $GOPATH
-
-ENTRYPOINT [ "/bin/mongodb_exporter" ]
+ENTRYPOINT [ "mongodb_exporter" ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ Requires [glide](https://github.com/Masterminds/glide) for dependency management
     make build
     ./mongodb_exporter -h
 
+## Building Docker image
+
+To keep the image size small (~15MB) we build the linux binary first which gets
+`COPY`'d into the Docker container (alpine base image)
+
+Create the linux binary
+
+    make release
+
+Build the Docker image
+
+    docker build -t mongodb_exporter .
+
+Verify Docker image runs
+
+    docker run --rm mongodb_exporter -h
+
 The mongodb url can contain credentials which can be seen by other users on the system when passed in as command line flag.
 To pass in the mongodb url securely, you can set the MONGODB_URL environment variable instead.
 


### PR DESCRIPTION
instead of installing Go + dependencies in Dockerfile, just `COPY` the linux binary in

shrinks image from ~100+MB to ~15MB

This will also allow everyone to build `mongodb_exporter` in the Go version of their choice w/o having to modify `Dockerfile`