### PR TITLE
added basic collection level metrics

### DIFF
--- a/collector/collection_status.go
+++ b/collector/collection_status.go
@@ -1,0 +1,93 @@
+package collector
+
+import (
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var (
+	count = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "collection",
+		Name:      "total_objects",
+		Help:      "The number of objects or documents in this collection",
+	}, []string{"ns"})
+
+	size = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "collection",
+		Name:      "size_bytes",
+		Help:      "The total size in memory of all records in a collection",
+	}, []string{"ns"})
+
+	avgObjSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "collection",
+		Name:      "avg_objsize_bytes",
+		Help:      "The average size of an object in the collection",
+	}, []string{"ns"})
+
+	storageSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "collection",
+		Name:      "storage_size_bytes",
+		Help:      "The total amount of storage allocated to this collection for document storage",
+	}, []string{"ns"})
+
+	collIndexSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "collection",
+		Name:      "index_size_bytes",
+		Help:      "The total size of all indexes",
+	}, []string{"ns"})
+)
+
+type CollectionStatus struct {
+	Name        string `bson:"ns"`
+	Count       int32  `bson:"count"`
+	Size        int32  `bson:"size"`
+	AvgSize     int32  `bson:"avgObjSize"`
+	StorageSize int32  `bson:"storageSize"`
+	IndexSize   int32  `bson:"totalIndexSize"`
+}
+
+func (collStatus *CollectionStatus) Export(ch chan<- prometheus.Metric) {
+	count.WithLabelValues(collStatus.Name).Set(float64(collStatus.Count))
+	size.WithLabelValues(collStatus.Name).Set(float64(collStatus.Size))
+	avgObjSize.WithLabelValues(collStatus.Name).Set(float64(collStatus.AvgSize))
+	storageSize.WithLabelValues(collStatus.Name).Set(float64(collStatus.StorageSize))
+	collIndexSize.WithLabelValues(collStatus.Name).Set(float64(collStatus.IndexSize))
+
+	count.Collect(ch)
+	size.Collect(ch)
+	avgObjSize.Collect(ch)
+	storageSize.Collect(ch)
+	collIndexSize.Collect(ch)
+
+	count.Reset()
+	size.Reset()
+	avgObjSize.Reset()
+	storageSize.Reset()
+	collIndexSize.Reset()
+}
+
+func (collStatus *CollectionStatus) Describe(ch chan<- *prometheus.Desc) {
+	count.Describe(ch)
+	size.Describe(ch)
+	avgObjSize.Describe(ch)
+	storageSize.Describe(ch)
+	collIndexSize.Describe(ch)
+}
+
+func GetCollectionStatus(session *mgo.Session, db string, collection string) *CollectionStatus {
+	var collStatus CollectionStatus
+	err := session.DB(db).Run(bson.D{{"collStats", collection}, {"scale", 1}}, &collStatus)
+	if err != nil {
+		glog.Error(err)
+		return nil
+	}
+
+	return &collStatus
+}

--- a/collector/collection_status.go
+++ b/collector/collection_status.go
@@ -91,3 +91,18 @@ func GetCollectionStatus(session *mgo.Session, db string, collection string) *Co
 
 	return &collStatus
 }
+
+func CollectCollectionStatus(session *mgo.Session, db string, ch chan<- prometheus.Metric) {
+	collection_names, err := session.DB(db).CollectionNames()
+	if err != nil {
+		glog.Error("Failed to get collection names for db=" + db)
+		return
+	}
+	for _, collection_name := range collection_names {
+		collStats := GetCollectionStatus(session, db, collection_name)
+		if collStats != nil {
+			glog.Infof("exporting Database Metrics for db=%q, table=%q", db, collection_name)
+			collStats.Export(ch)
+		}
+	}
+}

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -14,14 +14,15 @@ var (
 
 // MongodbCollectorOpts is the options of the mongodb collector.
 type MongodbCollectorOpts struct {
-	URI                    string
-	TLSCertificateFile     string
-	TLSPrivateKeyFile      string
-	TLSCaFile              string
-	TLSHostnameValidation  bool
-	CollectReplSet         bool
-	CollectOplog           bool
-	CollectDatabaseMetrics bool
+	URI                      string
+	TLSCertificateFile       string
+	TLSPrivateKeyFile        string
+	TLSCaFile                string
+	TLSHostnameValidation    bool
+	CollectReplSet           bool
+	CollectOplog             bool
+	CollectDatabaseMetrics   bool
+	CollectCollectionMetrics bool
 }
 
 func (in MongodbCollectorOpts) toSessionOps() shared.MongoSessionOpts {
@@ -75,6 +76,11 @@ func (exporter *MongodbCollector) Collect(ch chan<- prometheus.Metric) {
 			glog.Info("Collecting Database Metrics")
 			exporter.collectDatabaseStatus(mongoSess, ch)
 		}
+
+		if exporter.Opts.CollectCollectionMetrics {
+			glog.Info("Collection Collection Metrics")
+			exporter.collectCollectionStatus(mongoSess, ch)
+		}
 	}
 }
 
@@ -123,6 +129,31 @@ func (exporter *MongodbCollector) collectDatabaseStatus(session *mgo.Session, ch
 				glog.Infof("exporting Database Metrics for db=%q", dbStatus.Name)
 				dbStatus.Export(ch)
 			}
+		}
+	}
+}
+
+func (exporter *MongodbCollector) collectCollectionStatus(session *mgo.Session, ch chan<- prometheus.Metric) {
+	database_names, err := session.DatabaseNames()
+	if err != nil {
+		glog.Error("failed to get database names")
+		return
+	}
+	for _, db := range database_names {
+		if db != "admin" && db != "test" {
+			collection_names, err := session.DB(db).CollectionNames()
+			if err != nil {
+				glog.Error("Failed to get collection names for db=" + db)
+				continue
+			}
+			for _, collection_name := range collection_names {
+				collStats := GetCollectionStatus(session, db, collection_name)
+				if collStats != nil {
+					glog.Infof("exporting Database Metrics for db=%q, table=%q", db, collection_name)
+					collStats.Export(ch)
+				}
+			}
+
 		}
 	}
 }

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -122,13 +122,13 @@ func (exporter *MongodbCollector) collectDatabaseStatus(session *mgo.Session, ch
 		return
 	}
 	for _, db := range all {
-		if db != "admin" && db != "test" {
-			dbStatus := GetDatabaseStatus(session, db)
-
-			if dbStatus != nil {
-				glog.Infof("exporting Database Metrics for db=%q", dbStatus.Name)
-				dbStatus.Export(ch)
-			}
+		if db == "admin" || db == "test" {
+			continue
+		}
+		dbStatus := GetDatabaseStatus(session, db)
+		if dbStatus != nil {
+			glog.Infof("exporting Database Metrics for db=%q", dbStatus.Name)
+			dbStatus.Export(ch)
 		}
 	}
 }
@@ -140,20 +140,9 @@ func (exporter *MongodbCollector) collectCollectionStatus(session *mgo.Session, 
 		return
 	}
 	for _, db := range database_names {
-		if db != "admin" && db != "test" {
-			collection_names, err := session.DB(db).CollectionNames()
-			if err != nil {
-				glog.Error("Failed to get collection names for db=" + db)
-				continue
-			}
-			for _, collection_name := range collection_names {
-				collStats := GetCollectionStatus(session, db, collection_name)
-				if collStats != nil {
-					glog.Infof("exporting Database Metrics for db=%q, table=%q", db, collection_name)
-					collStats.Export(ch)
-				}
-			}
-
+		if db == "admin" || db == "test" {
+			continue
 		}
+		CollectCollectionStatus(session, db, ch)
 	}
 }

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -50,6 +50,7 @@ var (
 	mongodbCollectOplog                 = flag.Bool("mongodb.collect.oplog", true, "collect Mongodb Oplog status")
 	mongodbCollectReplSet               = flag.Bool("mongodb.collect.replset", true, "collect Mongodb replica set status")
 	mongodbCollectDatabaseMetrics       = flag.Bool("mongodb.collect.database", false, "collect MongoDB database metrics")
+	mongodbCollectCollectionMetrics     = flag.Bool("mongodb.collect.collection", false, "Collect MongoDB collection metrics")
 	version                             = flag.Bool("version", false, "Print mongodb_exporter version")
 )
 
@@ -140,14 +141,15 @@ func startWebServer() {
 
 func registerCollector() {
 	mongodbCollector := collector.NewMongodbCollector(collector.MongodbCollectorOpts{
-		URI:                    *mongodbURIFlag,
-		TLSCertificateFile:     *mongodbTLSCert,
-		TLSPrivateKeyFile:      *mongodbTLSPrivateKey,
-		TLSCaFile:              *mongodbTLSCa,
-		TLSHostnameValidation:  !(*mongodbTLSDisableHostnameValidation),
-		CollectOplog:           *mongodbCollectOplog,
-		CollectReplSet:         *mongodbCollectReplSet,
-		CollectDatabaseMetrics: *mongodbCollectDatabaseMetrics,
+		URI:                      *mongodbURIFlag,
+		TLSCertificateFile:       *mongodbTLSCert,
+		TLSPrivateKeyFile:        *mongodbTLSPrivateKey,
+		TLSCaFile:                *mongodbTLSCa,
+		TLSHostnameValidation:    !(*mongodbTLSDisableHostnameValidation),
+		CollectOplog:             *mongodbCollectOplog,
+		CollectReplSet:           *mongodbCollectReplSet,
+		CollectDatabaseMetrics:   *mongodbCollectDatabaseMetrics,
+		CollectCollectionMetrics: *mongodbCollectCollectionMetrics,
 	})
 	prometheus.MustRegister(mongodbCollector)
 }


### PR DESCRIPTION
hi @dcu   this pull request is for collecting collection level metrics,  and it can be controlled by flag mongodb.collect.collection so that user can choose collect it or not.  

btw, do you have plan to collect the collection level wiredtiger related metrics?   I think it may be useful for troubleshooting if I understand wiredtiger well, but currently I am still can't understand these metrics well.  so I didn't collect it right now. 

thanks