### PR TITLE
Use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
+FROM       golang:alpine as builder
+
+RUN apk --no-cache add curl git make perl
+RUN curl -s https://glide.sh/get | sh
+RUN git clone https://github.com/dcu/mongodb_exporter.git /go/src/github.com/dcu/mongodb_exporter
+RUN cd /go/src/github.com/dcu/mongodb_exporter && make release
+
 FROM       alpine:3.4
 MAINTAINER David Cuadrado <dacuad@facebook.com>
 EXPOSE     9001
 
 RUN apk add --update ca-certificates
-COPY release/mongodb_exporter-linux-amd64 /usr/local/bin/mongodb_exporter
+COPY --from=builder /go/src/github.com/dcu/mongodb_exporter/release/mongodb_exporter-linux-amd64 /usr/local/bin/mongodb_exporter
 
 ENTRYPOINT [ "mongodb_exporter" ]

--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ Requires [glide](https://github.com/Masterminds/glide) for dependency management
 
 ## Building Docker image
 
-To keep the image size small (~15MB) we build the linux binary first which gets
-`COPY`'d into the Docker container (alpine base image)
-
-Create the linux binary
-
-    make release
-
 Build the Docker image
 
     docker build -t mongodb_exporter .


### PR DESCRIPTION
Hi @dcu 

I was wondering if you're interested in using multistage builds?  From Docker 17.05+ you can now build the golang binary in one container and then load it into another container automatically in a single `docker build` step without sacrificing image size.

https://docs.docker.com/engine/userguide/eng-image/multistage-build/

The advantage is that you could then auto-build the container in docker hub.

Let me know if you'd like me to make any other changes.

Thanks for building the project.

Ben