### PR TITLE
use COPY instead of RUN git clone origin master in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM       golang:alpine as builder
 
 RUN apk --no-cache add curl git make perl
 RUN curl -s https://glide.sh/get | sh
-RUN git clone https://github.com/dcu/mongodb_exporter.git /go/src/github.com/dcu/mongodb_exporter
+COPY . /go/src/github.com/dcu/mongodb_exporter
 RUN cd /go/src/github.com/dcu/mongodb_exporter && make release
 
 FROM       alpine:3.4


### PR DESCRIPTION
The current Dockerfile clones from github origin master the code when building it.
It doesn't allow you to build a release / container of your current development.
By `COPY`ing instead of `RUN git clone` we can have a better workflow for developping and building containers.