### PR TITLE
Add profile collector

### DIFF
--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -32,6 +32,7 @@ type MongodbCollectorOpts struct {
 	CollectTopMetrics        bool
 	CollectDatabaseMetrics   bool
 	CollectCollectionMetrics bool
+	CollectProfileMetrics    bool
 	CollectConnPoolStats     bool
 	UserName                 string
 	AuthMechanism            string
@@ -106,6 +107,11 @@ func (exporter *MongodbCollector) Collect(ch chan<- prometheus.Metric) {
 		if exporter.Opts.CollectCollectionMetrics {
 			glog.Info("Collection Collection Metrics")
 			exporter.collectCollectionStatus(mongoSess, ch)
+		}
+
+		if exporter.Opts.CollectProfileMetrics {
+			glog.Info("Collection Profile Metrics")
+			exporter.collectProfileStatus(mongoSess, ch)
 		}
 
 		if exporter.Opts.CollectConnPoolStats {
@@ -188,6 +194,20 @@ func (exporter *MongodbCollector) collectCollectionStatus(session *mgo.Session, 
 			continue
 		}
 		CollectCollectionStatus(session, db, ch)
+	}
+}
+
+func (exporter *MongodbCollector) collectProfileStatus(session *mgo.Session, ch chan<- prometheus.Metric) {
+	all, err := session.DatabaseNames()
+	if err != nil {
+		glog.Error("failed to get database names: %s", err)
+		return
+	}
+	for _, db := range all {
+		if db == "admin" || db == "test" {
+			continue
+		}
+		CollectProfileStatus(session, db, ch)
 	}
 }
 

--- a/collector/profile_status.go
+++ b/collector/profile_status.go
@@ -1,0 +1,44 @@
+package collector
+
+import (
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"time"
+)
+
+var (
+	profileCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "profile",
+		Name:      "slow_query_30s_count",
+		Help:      "The number of slow queries in this database during last 30 seconds",
+	}, []string{"database"})
+)
+
+type ProfileStatus struct {
+	Name  string `bson:"database"`
+	Count int    `bson:"count"`
+}
+
+func (profileStatus *ProfileStatus) Export(ch chan<- prometheus.Metric) {
+	profileCount.WithLabelValues(profileStatus.Name).Set(float64(profileStatus.Count))
+	profileCount.Collect(ch)
+	profileCount.Reset()
+}
+
+func (profileStatus *ProfileStatus) Describe(ch chan<- *prometheus.Desc) {
+	profileCount.Describe(ch)
+}
+
+func CollectProfileStatus(session *mgo.Session, db string, ch chan<- prometheus.Metric) {
+	ts := time.Now().Add(-time.Duration(time.Second * 30))
+	count, err := session.DB(db).C("system.profile").Find(bson.M{"ts": bson.M{"$gt": ts}}).Count()
+	if err != nil {
+		glog.Error(err)
+		return
+	}
+	profileStatus := ProfileStatus{db, count}
+	profileStatus.Export(ch)
+}

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -54,6 +54,7 @@ var (
 	mongodbCollectTopMetrics            = flag.Bool("mongodb.collect.top", false, "collect Mongodb Top metrics")
 	mongodbCollectDatabaseMetrics       = flag.Bool("mongodb.collect.database", false, "collect MongoDB database metrics")
 	mongodbCollectCollectionMetrics     = flag.Bool("mongodb.collect.collection", false, "Collect MongoDB collection metrics")
+	mongodbCollectProfileMetrics        = flag.Bool("mongodb.collect.profile", false, "Collect MongoDB profile metrics")
 	mongodbCollectConnPoolStats         = flag.Bool("mongodb.collect.connpoolstats", false, "Collect MongoDB connpoolstats")
 	version                             = flag.Bool("version", false, "Print mongodb_exporter version")
 )
@@ -155,6 +156,7 @@ func registerCollector() {
 		CollectTopMetrics:        *mongodbCollectTopMetrics,
 		CollectDatabaseMetrics:   *mongodbCollectDatabaseMetrics,
 		CollectCollectionMetrics: *mongodbCollectCollectionMetrics,
+		CollectProfileMetrics:    *mongodbCollectProfileMetrics,
 		CollectConnPoolStats:     *mongodbCollectConnPoolStats,
 		UserName:                 *mongodbUserName,
 		AuthMechanism:            *mongodbAuthMechanism,


### PR DESCRIPTION
Add a profiler collector: This PR adds a collector that will, for a given database, count the number of objects in the `system.profile` collection that have been inserted during the last 30 seconds.
The `system.profile` collection, contains, if mongodb profiler is enabled, slow requests (and might contain other requests but not sure which).
Also, by default, this collection is capped to 1MB , so we cannot simply count the total number of documents in the collection, return it as-is, and use `rate()` to see overtime when we have slow requets.

@dcu are you interested by such a collector / metric ?
Do you have idea to improve it, such as , for example, be able to configure the time range for the Find().Count() ? Would this belong to the database collector ?
Should I add a (configurable ?) `millis` criteria to the `Find()` ?