### PR TITLE
add the required files to build a mongodb_exporter snap

### DIFF
--- a/snap/daemon_arguments
+++ b/snap/daemon_arguments
@@ -1,0 +1,61 @@
+# Set the command-line arguments to pass to the server.
+ARGS=""
+
+# The following options are supported by prometheus-mongodb-exporter :
+#  -alsologtostderr
+#        log to standard error as well as files
+#  -auth.pass string
+#        Password for basic auth.
+#  -auth.user string
+#        Username for basic auth.
+#  -groups.enabled string
+#        Comma-separated list of groups to use, for more info see: docs.mongodb.org/manual/reference/command/serverStatus/ (default "asserts,durability,background_flushing,connections,extra_info,global_lock,index_counters,network,op_counters,op_counters_repl,memory,locks,metrics")
+#  -log_backtrace_at value
+#        when logging hits line file:N, emit a stack trace
+#  -log_dir string
+#        If non-empty, write log files in this directory
+#  -logtostderr
+#        log to standard error instead of files
+#  -mongodb.collect.database
+#        collect MongoDB database metrics
+#  -mongodb.collect.oplog
+#        collect Mongodb Oplog status (default true)
+#  -mongodb.collect.replset
+#        collect Mongodb replica set status (default true)
+#  -mongodb.tls-ca string
+#        Path to PEM file that conains the CAs that are trused for server connections.
+#        If provided: MongoDB servers connecting to should present a certificate signed by one of this CAs.
+#        If not provided: System default CAs are used.
+#  -mongodb.tls-cert string
+#        Path to PEM file that conains the certificate (and optionally also the private key in PEM format).
+#        This should include the whole certificate chain.
+#        If provided: The connection will be opened via TLS to the MongoDB server.
+#  -mongodb.tls-disable-hostname-validation
+#        Do hostname validation for server connection.
+#  -mongodb.tls-private-key string
+#        Path to PEM file that conains the private key (if not contained in mongodb.tls-cert file).
+#  -mongodb.uri string
+#        Mongodb URI, format: [mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options] (default "mongodb://localhost:27017")
+#  -stderrthreshold value
+#        logs at or above this threshold go to stderr
+#  -v value
+#        log level for V logs
+#  -version
+#        Print mongodb_exporter version
+#  -vmodule value
+#        comma-separated list of pattern=N settings for file-filtered logging
+#  -web.listen-address string
+#        Address on which to expose metrics and web interface. (default ":9001")
+#  -web.metrics-path string
+#        Path under which to expose metrics. (default "/metrics")
+#  -web.tls-cert string
+#        Path to PEM file that conains the certificate (and optionally also the private key in PEM format).
+#        This should include the whole certificate chain.
+#        If provided: The web socket will be a HTTPS socket.
+#        If not provided: Only HTTP.
+#  -web.tls-client-ca string
+#        Path to PEM file that conains the CAs that are trused for client connections.
+#        If provided: Connecting clients should present a certificate signed by one of this CAs.
+#        If not provided: Every client will be accepted.
+#  -web.tls-private-key string
+#        Path to PEM file that conains the private key (if not contained in web.tls-cert file).

--- a/snap/snap_config_wrapper
+++ b/snap/snap_config_wrapper
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+test -e $SNAP_DATA/daemon_arguments || cp $SNAP/etc/prometheus-mongodb-exporter/daemon_arguments.example $SNAP_DATA/daemon_arguments
+
+. $SNAP_DATA/daemon_arguments
+exec $SNAP/bin/prometheus-mongodb-exporter $ARGS

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,38 @@
+name: prometheus-mongodb-exporter
+version: 20171129
+summary: Prometheus mongodb Exporter
+description: |
+  Exporter that exposes information gathered from mongodb for use by the Prometheus monitoring system
+confinement: strict
+grade: stable
+apps:
+  mongodb-exporter:
+    command: 'bin/prometheus-mongodb-exporter.wrapper'
+    plugs: [network-bind, network]
+    daemon: simple
+parts:
+  mongodb-exporter:
+    plugin: go
+    source: https://github.com/dcu/mongodb_exporter.git
+    go-importpath: github.com/dcu/mongodb_exporter
+    build: |
+        sudo add-apt-repository -y ppa:masterminds/glide && sudo apt-get update
+        sudo apt-get install -y glide
+        export GOPATH=$(pwd)/../go
+        cd $GOPATH/src/github.com/dcu/mongodb_exporter
+        make build
+    install: |
+        mkdir $SNAPCRAFT_PART_INSTALL/bin
+        cp -p ../go/src/github.com/dcu/mongodb_exporter/mongodb_exporter $SNAPCRAFT_PART_INSTALL/bin/prometheus-mongodb-exporter
+  snap-wrappers:
+    plugin: dump
+    source: .
+    organize:
+      snap_config_wrapper: bin/prometheus-mongodb-exporter.wrapper
+      daemon_arguments: etc/prometheus-mongodb-exporter/daemon_arguments.example
+    stage:
+      - bin/prometheus-mongodb-exporter.wrapper
+      - etc/prometheus-mongodb-exporter/daemon_arguments.example
+    prime:
+      - bin/prometheus-mongodb-exporter.wrapper
+      - etc/prometheus-mongodb-exporter/daemon_arguments.example


### PR DESCRIPTION
Hi !

I have created a mongodb_exporter snap (https://snapcraft.io/prometheus-mongodb-exporter/), which works well, and I think it should be included and built upstream now (you can even get it built automatically from github - see https://build.snapcraft.io/).

You can find more information about snaps at : https://snapcraft.io/

To test the current snap (steps for Ubuntu - see the above URL for other distros) : 
```
sudo apt-get install snapd
sudo snap install prometheus-mongodb-exporter
sudo vim /var/snap/prometheus-mongodb-exporter/current/daemon_arguments # and edit ARGS with whatever parameters you want to pass to mongodb_exporter
sudo service snap.prometheus-mongodb-exporter.mongodb-exporter.service restart
```

If you have any questions about snaps, happy to answer them :)

Cheers !