### PR TITLE
remove remote repo cloning as it is redundant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ env:
 
 before_install:
   - sudo apt-get install curl git make perl
-  - git clone https://github.com/dcu/mongodb_exporter.git $GOPATH/src/github.com/dcu/mongodb_exporter
-  - cd ../../dcu/mongodb_exporter && curl -s https://glide.sh/get | sh
+  - curl -s https://glide.sh/get | sh
 
 script:
   - make release


### PR DESCRIPTION
Fix .travis.yml - now it works
See triggered build output here: https://travis-ci.org/dcu/mongodb_exporter/builds