### PR TITLE
Add replsetConf metrics

### DIFF
--- a/collector/collection_status.go
+++ b/collector/collection_status.go
@@ -101,7 +101,7 @@ func CollectCollectionStatus(session *mgo.Session, db string, ch chan<- promethe
 	for _, collection_name := range collection_names {
 		collStats := GetCollectionStatus(session, db, collection_name)
 		if collStats != nil {
-			glog.Infof("exporting Database Metrics for db=%q, table=%q", db, collection_name)
+			glog.V(1).Infof("exporting Database Metrics for db=%q, table=%q", db, collection_name)
 			collStats.Export(ch)
 		}
 	}

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -1,6 +1,8 @@
 package collector
 
 import (
+	"time"
+
 	"github.com/dcu/mongodb_exporter/shared"
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,6 +38,7 @@ type MongodbCollectorOpts struct {
 	CollectConnPoolStats     bool
 	UserName                 string
 	AuthMechanism            string
+	SocketTimeout            time.Duration
 }
 
 func (in MongodbCollectorOpts) toSessionOps() shared.MongoSessionOpts {
@@ -47,6 +50,7 @@ func (in MongodbCollectorOpts) toSessionOps() shared.MongoSessionOpts {
 		TLSHostnameValidation: in.TLSHostnameValidation,
 		UserName:              in.UserName,
 		AuthMechanism:         in.AuthMechanism,
+		SocketTimeout:         in.SocketTimeout,
 	}
 }
 

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -68,6 +68,7 @@ func NewMongodbCollector(opts MongodbCollectorOpts) *MongodbCollector {
 func (exporter *MongodbCollector) Describe(ch chan<- *prometheus.Desc) {
 	(&ServerStatus{}).Describe(ch)
 	(&ReplSetStatus{}).Describe(ch)
+	(&ReplSetConf{}).Describe(ch)
 	(&DatabaseStatus{}).Describe(ch)
 
 	if exporter.Opts.CollectTopMetrics {
@@ -88,6 +89,7 @@ func (exporter *MongodbCollector) Collect(ch chan<- prometheus.Metric) {
 		if exporter.Opts.CollectReplSet {
 			glog.Info("Collecting ReplSet Status")
 			exporter.collectReplSetStatus(mongoSess, ch)
+			exporter.collectReplSetConf(mongoSess, ch)
 		}
 		if exporter.Opts.CollectOplog {
 			glog.Info("Collecting Oplog Status")
@@ -143,6 +145,17 @@ func (exporter *MongodbCollector) collectReplSetStatus(session *mgo.Session, ch 
 	}
 
 	return replSetStatus
+}
+
+func (exporter *MongodbCollector) collectReplSetConf(session *mgo.Session, ch chan<- prometheus.Metric) *ReplSetConf {
+	replSetConf := GetReplSetConf(session)
+
+	if replSetConf != nil {
+		glog.Info("exporting ReplSetConf Metrics")
+		replSetConf.Export(ch)
+	}
+
+	return replSetConf
 }
 
 func (exporter *MongodbCollector) collectOplogStatus(session *mgo.Session, ch chan<- prometheus.Metric) *OplogStatus {

--- a/collector/oplog_tail.go
+++ b/collector/oplog_tail.go
@@ -63,7 +63,7 @@ func GetOplogTailStats(session *mgo.Session) *OplogTailStats {
 	if tailer == nil {
 		tailer = &OplogTailStats{}
 		// Start a tailer with a copy of the session (to avoid messing with the other metrics in the session)
-		tailer.Start(session.Copy())
+		go tailer.Start(session.Copy())
 	}
 
 	return tailer

--- a/collector/oplog_tail.go
+++ b/collector/oplog_tail.go
@@ -1,6 +1,8 @@
 package collector
 
 import (
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rwynn/gtm"
@@ -27,6 +29,11 @@ var tailer *OplogTailStats
 type OplogTailStats struct{}
 
 func (o *OplogTailStats) Start(session *mgo.Session) {
+	// Override the socket timeout for oplog tailing
+	// Here we want a long-running socket, otherwise we cause lots of locks
+	// which seriously impede oplog performance
+	session.SetSocketTimeout(time.Second * 120)
+
 	defer session.Close()
 	session.SetMode(mgo.Monotonic, true)
 

--- a/collector/oplog_tail.go
+++ b/collector/oplog_tail.go
@@ -1,8 +1,7 @@
 package collector
 
 import (
-	"fmt"
-
+	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rwynn/gtm"
 	"gopkg.in/mgo.v2"
@@ -32,6 +31,7 @@ func (o *OplogTailStats) Start(session *mgo.Session) {
 	session.SetMode(mgo.Monotonic, true)
 
 	ctx := gtm.Start(session, nil)
+	defer ctx.Stop()
 
 	// ctx.OpC is a channel to read ops from
 	// ctx.ErrC is a channel to read errors from
@@ -40,8 +40,7 @@ func (o *OplogTailStats) Start(session *mgo.Session) {
 		// loop forever receiving events
 		select {
 		case err := <-ctx.ErrC:
-			// handle errors
-			fmt.Println(err)
+			glog.Errorf("Error getting entry from oplog: %v", err)
 		case op := <-ctx.OpC:
 			oplogEntryCount.WithLabelValues(op.Namespace, op.Operation).Add(1)
 		}

--- a/collector/oplog_tail.go
+++ b/collector/oplog_tail.go
@@ -40,6 +40,7 @@ func (o *OplogTailStats) Start(session *mgo.Session) {
 		// loop forever receiving events
 		select {
 		case err := <-ctx.ErrC:
+			oplogTailError.Add(1)
 			glog.Errorf("Error getting entry from oplog: %v", err)
 		case op := <-ctx.OpC:
 			oplogEntryCount.WithLabelValues(op.Namespace, op.Operation).Add(1)

--- a/collector/replset_conf.go
+++ b/collector/replset_conf.go
@@ -1,0 +1,144 @@
+package collector
+
+import (
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	memberHidden = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: subsystem,
+		Name:      "member_hidden",
+		Help:      "This field conveys if the member is hidden (1) or not-hidden (0).",
+	}, []string{"id", "host"})
+	memberArbiter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: subsystem,
+		Name:      "member_arbiter",
+		Help:      "This field conveys if the member is an arbiter (1) or not (0).",
+	}, []string{"id", "host"})
+	memberBuildIndexes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: subsystem,
+		Name:      "member_build_indexes",
+		Help:      "This field conveys if the member is  builds indexes (1) or not (0).",
+	}, []string{"id", "host"})
+	memberPriority = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: subsystem,
+		Name:      "member_priority",
+		Help:      "This field conveys the priority of a given member",
+	}, []string{"id", "host"})
+	memberVotes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: subsystem,
+		Name:      "member_votes",
+		Help:      "This field conveys the number of votes of a given member",
+	}, []string{"id", "host"})
+)
+
+// Although the docs say that it returns a map with id etc. it *actually* returns
+// that wrapped in a map
+type OuterReplSetConf struct {
+	Config ReplSetConf `bson:"config"`
+}
+
+// ReplSetConf keeps the data returned by the GetReplSetConf method
+type ReplSetConf struct {
+	Id      string       `bson:"_id"`
+	Version int          `bson:"version"`
+	Members []MemberConf `bson:"members"`
+}
+
+/*
+Example:
+"settings" : {
+	"chainingAllowed" : true,
+	"heartbeatIntervalMillis" : 2000,
+	"heartbeatTimeoutSecs" : 10,
+	"electionTimeoutMillis" : 5000,
+	"getLastErrorModes" : {
+
+	},
+	"getLastErrorDefaults" : {
+		"w" : 1,
+		"wtimeout" : 0
+	}
+}
+*/
+type ReplSetConfSettings struct {
+}
+
+// Member represents an array element of ReplSetConf.Members
+type MemberConf struct {
+	Id           int32  `bson:"_id"`
+	Host         string `bson:"host"`
+	ArbiterOnly  bool   `bson:"arbiterOnly"`
+	BuildIndexes bool   `bson:"buildIndexes"`
+	Hidden       bool   `bson:"hidden"`
+	Priority     int32  `bson:"priority"`
+
+	Tags       map[string]string `bson:"tags"`
+	SlaveDelay float64           `bson:"saveDelay"`
+	Votes      int32             `bson:"votes"`
+}
+
+// Export exports the replSetGetStatus stati to be consumed by prometheus
+func (replConf *ReplSetConf) Export(ch chan<- prometheus.Metric) {
+	for _, member := range replConf.Members {
+		ls := prometheus.Labels{
+			"id":   replConf.Id,
+			"host": member.Host,
+		}
+		if member.Hidden {
+			memberHidden.With(ls).Set(1)
+		} else {
+			memberHidden.With(ls).Set(0)
+		}
+
+		if member.ArbiterOnly {
+			memberArbiter.With(ls).Set(1)
+		} else {
+			memberArbiter.With(ls).Set(0)
+		}
+
+		if member.BuildIndexes {
+			memberBuildIndexes.With(ls).Set(1)
+		} else {
+			memberBuildIndexes.With(ls).Set(0)
+		}
+
+		memberPriority.With(ls).Set(float64(member.Priority))
+		memberVotes.With(ls).Set(float64(member.Votes))
+	}
+	// collect metrics
+	memberHidden.Collect(ch)
+	memberArbiter.Collect(ch)
+	memberBuildIndexes.Collect(ch)
+	memberPriority.Collect(ch)
+	memberVotes.Collect(ch)
+}
+
+// Describe describes the replSetGetStatus metrics for prometheus
+func (replConf *ReplSetConf) Describe(ch chan<- *prometheus.Desc) {
+	memberHidden.Describe(ch)
+	memberArbiter.Describe(ch)
+	memberBuildIndexes.Describe(ch)
+	memberPriority.Describe(ch)
+	memberVotes.Describe(ch)
+}
+
+// GetReplSetConf returns the replica status info
+func GetReplSetConf(session *mgo.Session) *ReplSetConf {
+	result := &OuterReplSetConf{}
+	err := session.DB("admin").Run(bson.D{{"replSetGetConfig", 1}}, result)
+	if err != nil {
+		glog.Error("Failed to get replSet config.")
+		return nil
+	}
+	return &result.Config
+}

--- a/collector/server_status.go
+++ b/collector/server_status.go
@@ -56,6 +56,7 @@ type ServerStatus struct {
 
 	Opcounters     *OpcountersStats     `bson:"opcounters"`
 	OpcountersRepl *OpcountersReplStats `bson:"opcountersRepl"`
+	TCMallocStats  *TCMallocStats       `bson:"tcmalloc"`
 	Mem            *MemStats            `bson:"mem"`
 	Metrics        *MetricsStats        `bson:"metrics"`
 
@@ -103,6 +104,9 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 	}
 	if status.OpcountersRepl != nil {
 		status.OpcountersRepl.Export(ch)
+	}
+	if status.TCMallocStats != nil {
+	    status.TCMallocStats.Export(ch)
 	}
 	if status.Mem != nil {
 		status.Mem.Export(ch)
@@ -167,6 +171,9 @@ func (status *ServerStatus) Describe(ch chan<- *prometheus.Desc) {
 	}
 	if status.OpcountersRepl != nil {
 		status.OpcountersRepl.Describe(ch)
+	}
+	if status.TCMallocStats != nil {
+	    status.TCMallocStats.Describe(ch)
 	}
 	if status.Mem != nil {
 		status.Mem.Describe(ch)

--- a/collector/tcmalloc.go
+++ b/collector/tcmalloc.go
@@ -1,0 +1,121 @@
+package collector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	tcmallocGeneral = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      "tcmalloc_generic_heap",
+		Help:      "High-level summary metricsInternal metrics from tcmalloc",
+	}, []string{"type"})
+	tcmallocPageheapBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      "tcmalloc_pageheap_bytes",
+		Help:      "Sizes for tcpmalloc pageheaps",
+	}, []string{"type"})
+	tcmallocPageheapCounts = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      "tcmalloc_pageheap_count",
+		Help:      "Sizes for tcpmalloc pageheaps",
+	}, []string{"type"})
+
+	tcmallocCacheBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      "tcmalloc_cache_bytes",
+		Help:      "Sizes for tcpmalloc caches in bytes",
+	}, []string{"cache", "type"})
+
+	tcmallocAggressiveDecommit = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "tcmalloc_aggressive_memory_decommit",
+		Help:      "Whether aggressive_memory_decommit is on",
+	})
+
+	tcmallocFreeBytes = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "tcmalloc_free_bytes",
+		Help:      "Total free bytes of tcmalloc",
+	})
+)
+
+// TCMallocStats tracks the mem stats metrics.
+type TCMallocStats struct {
+	Generic GenericTCMAllocStats  `bson:"generic"`
+	Details DetailedTCMallocStats `bson:"tcmalloc"`
+}
+
+type GenericTCMAllocStats struct {
+	CurrentAllocatedBytes float64 `bson:"current_allocated_bytes"`
+	HeapSize              float64 `bson:"heap_size"`
+}
+
+type DetailedTCMallocStats struct {
+	PageheapFreeBytes          float64 `bson:"pageheap_free_bytes"`
+	PageheapUnmappedBytes      float64 `bson:"pageheap_unmapped_bytes"`
+	PageheapComittedBytes      float64 `bson:"pageheap_committed_bytes"`
+	PageheapScavengeCount      float64 `bson:"pageheap_scavenge_count"`
+	PageheapCommitCount        float64 `bson:"pageheap_commit_count"`
+	PageheapTotalCommitBytes   float64 `bson:"pageheap_total_commit_bytes"`
+	PageheapDecommitCount      float64 `bson:"pageheap_decommit_count"`
+	PageheapTotalDecommitBytes float64 `bson:"pageheap_total_decommit_bytes"`
+	PageheapReserveCount       float64 `bson:"pageheap_reserve_count"`
+	PageheapTotalReserveBytes  float64 `bson:"pageheap_total_reserve_bytes"`
+
+	MaxTotalThreadCacheBytes     float64 `bson:"max_total_thread_cache_bytes"`
+	CurrentTotalThreadCacheBytes float64 `bson:"current_total_thread_cache_bytes"`
+	CentralCacheFreeBytes        float64 `bson:"central_cache_free_bytes"`
+	TransferCacheFreeBytes       float64 `bson:"transfer_cache_free_bytes"`
+	ThreadCacheFreeBytes         float64 `bson:"thread_cache_free_bytes"`
+
+	TotalFreeBytes           float64 `bson:"total_free_bytes"`
+	AggressiveMemoryDecommit float64 `bson:"aggressive_memory_decommit"`
+}
+
+// Export exports the data to prometheus.
+func (m *TCMallocStats) Export(ch chan<- prometheus.Metric) {
+	// Generic metrics
+	tcmallocGeneral.WithLabelValues("allocated").Set(m.Generic.CurrentAllocatedBytes)
+	tcmallocGeneral.WithLabelValues("total").Set(m.Generic.HeapSize)
+	tcmallocGeneral.Collect(ch)
+
+	// Pageheap
+	tcmallocPageheapBytes.WithLabelValues("free").Set(m.Details.PageheapFreeBytes)
+	tcmallocPageheapBytes.WithLabelValues("unmapped").Set(m.Details.PageheapUnmappedBytes)
+	tcmallocPageheapBytes.WithLabelValues("comitted").Set(m.Details.PageheapComittedBytes)
+	tcmallocPageheapBytes.WithLabelValues("total_commit").Set(m.Details.PageheapTotalCommitBytes)
+	tcmallocPageheapBytes.WithLabelValues("total_decommit").Set(m.Details.PageheapTotalDecommitBytes)
+	tcmallocPageheapBytes.WithLabelValues("total_reserve").Set(m.Details.PageheapTotalReserveBytes)
+	tcmallocPageheapBytes.Collect(ch)
+
+	tcmallocPageheapCounts.WithLabelValues("scavenge").Set(m.Details.PageheapScavengeCount)
+	tcmallocPageheapCounts.WithLabelValues("commit").Set(m.Details.PageheapCommitCount)
+	tcmallocPageheapCounts.WithLabelValues("decommit").Set(m.Details.PageheapDecommitCount)
+	tcmallocPageheapCounts.WithLabelValues("reserve").Set(m.Details.PageheapReserveCount)
+	tcmallocPageheapCounts.Collect(ch)
+
+	tcmallocCacheBytes.WithLabelValues("thread_cache", "max_total").Set(m.Details.MaxTotalThreadCacheBytes)
+	tcmallocCacheBytes.WithLabelValues("thread_cache", "current_total").Set(m.Details.CurrentTotalThreadCacheBytes)
+	tcmallocCacheBytes.WithLabelValues("central_cache", "free").Set(m.Details.CentralCacheFreeBytes)
+	tcmallocCacheBytes.WithLabelValues("transfer_cache", "free").Set(m.Details.TransferCacheFreeBytes)
+	tcmallocCacheBytes.WithLabelValues("thread_cache", "free").Set(m.Details.ThreadCacheFreeBytes)
+	tcmallocCacheBytes.Collect(ch)
+
+	tcmallocAggressiveDecommit.Set(m.Details.AggressiveMemoryDecommit)
+	tcmallocAggressiveDecommit.Collect(ch)
+
+	tcmallocFreeBytes.Set(m.Details.TotalFreeBytes)
+	tcmallocFreeBytes.Collect(ch)
+
+}
+
+// Describe describes the metrics for prometheus
+func (m *TCMallocStats) Describe(ch chan<- *prometheus.Desc) {
+	tcmallocGeneral.Describe(ch)
+	tcmallocPageheapBytes.Describe(ch)
+	tcmallocPageheapCounts.Describe(ch)
+	tcmallocCacheBytes.Describe(ch)
+	tcmallocAggressiveDecommit.Describe(ch)
+	tcmallocFreeBytes.Describe(ch)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,17 +1,10 @@
-hash: 039dc285fae0ee4b97a236ec9935fff74f31b66c011fef0fdf64ab746d07a02a
-updated: 2018-03-15T15:08:18.90732609-07:00
+hash: 2daa265ce1037e5ac801ef074714e212b1ff69f2fea2e5c69a6c05ece9326f31
+updated: 2018-03-15T17:01:48.086832728-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
-- name: github.com/globalsign/mgo
-  version: baa28fcb8e7d5dfab92026c0920cb6c9ae72faa2
-  subpackages:
-  - bson
-  - internal/json
-  - internal/sasl
-  - internal/scram
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/protobuf
@@ -22,8 +15,6 @@ imports:
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
-- name: github.com/pkg/errors
-  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
@@ -43,7 +34,8 @@ imports:
   subpackages:
   - xfs
 - name: github.com/rwynn/gtm
-  version: c5642730dfa1ae9ceaebf33baa28d19a24bb0714
+  version: 495abc277593067479c3c528864191804ab04cf7
+  repo: https://github.com/jacksontj/gtm.git
 - name: github.com/serialx/hashring
   version: 6a9381c5a83e926b9f1fd907395a581e69747e96
 - name: gopkg.in/mgo.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,4 +9,5 @@ import:
   subpackages:
   - bson
 - package: github.com/rwynn/gtm
-  version: c5642730dfa1ae9ceaebf33baa28d19a24bb0714
+  version: 495abc277593067479c3c528864191804ab04cf7
+  repo: https://github.com/jacksontj/gtm.git

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -56,6 +56,7 @@ var (
 	mongodbCollectCollectionMetrics     = flag.Bool("mongodb.collect.collection", false, "Collect MongoDB collection metrics")
 	mongodbCollectProfileMetrics        = flag.Bool("mongodb.collect.profile", false, "Collect MongoDB profile metrics")
 	mongodbCollectConnPoolStats         = flag.Bool("mongodb.collect.connpoolstats", false, "Collect MongoDB connpoolstats")
+	mongodbSocketTimeout                = flag.Duration("mongodb.socket-timeout", 0, "timeout for socket operations to mongodb")
 	version                             = flag.Bool("version", false, "Print mongodb_exporter version")
 )
 
@@ -160,6 +161,7 @@ func registerCollector() {
 		CollectConnPoolStats:     *mongodbCollectConnPoolStats,
 		UserName:                 *mongodbUserName,
 		AuthMechanism:            *mongodbAuthMechanism,
+		SocketTimeout:            *mongodbSocketTimeout,
 	})
 	prometheus.MustRegister(mongodbCollector)
 }

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -26,6 +26,7 @@ type MongoSessionOpts struct {
 	TLSHostnameValidation bool
 	UserName              string
 	AuthMechanism         string
+	SocketTimeout         time.Duration
 }
 
 // MongoSession creates a Mongo session
@@ -55,7 +56,7 @@ func MongoSession(opts MongoSessionOpts) *mgo.Session {
 	}
 	session.SetMode(mgo.Eventual, true)
 	session.SetSyncTimeout(syncMongodbTimeout)
-	session.SetSocketTimeout(0)
+	session.SetSocketTimeout(opts.SocketTimeout)
 	return session
 }
 


### PR DESCRIPTION
We already pull the replsetStatus metrics, but things such as priority,
hidden, and votes are in the conf. This exposes them. For now the tags
mimic what is in mongo (so they match the docs) -- sadly this does mean
that the tags don't match what the other replset metrics have (set ->
id, etc.)