### PR TITLE
Fix for unescaped characters in regex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: deps
 
 release: deps
 	mkdir -p release
-	perl -p -i -e 's/{{VERSION}}/$(TAG)/g' mongodb_exporter.go
+	perl -p -i -e 's/\{\{VERSION}}/$(TAG)/g' mongodb_exporter.go
 	GOOS=darwin GOARCH=amd64 go build -o release/mongodb_exporter-darwin-amd64 $(package)
 	GOOS=linux GOARCH=amd64 go build -o release/mongodb_exporter-linux-amd64 $(package)
-	perl -p -i -e 's/$(TAG)/{{VERSION}}/g' mongodb_exporter.go
+	perl -p -i -e 's/$(TAG)/\{\{VERSION}}/g' mongodb_exporter.go


### PR DESCRIPTION
This fixes #85:
```
perl -p -i -e 's/{{VERSION}}/v1.0.0/g' mongodb_exporter.go
Unescaped left brace in regex is illegal here in regex; marked by <-- HERE in m/{{ <-- HERE VERSION}}/ at -e line 1.
make: *** [Makefile:19: release] Error 255
The command '/bin/sh -c cd /go/src/github.com/dcu/mongodb_exporter && make release' returned a non-zero code: 2
```