### PR TITLE
Support latest release of Prometheus client

### DIFF
--- a/collector/asserts.go
+++ b/collector/asserts.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	assertsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	assertsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "asserts_total",
 		Help:      "The asserts document reports the number of asserts on the database. While assert errors are typically uncommon, if there are non-zero values for the asserts, you should check the log file for the mongod process for more information. In many cases these errors are trivial, but are worth investigating.",

--- a/collector/background_flushing.go
+++ b/collector/background_flushing.go
@@ -7,13 +7,13 @@ import (
 )
 
 var (
-	backgroundFlushingflushesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	backgroundFlushingflushesTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "flushes_total",
 		Help:      "flushes is a counter that collects the number of times the database has flushed all writes to disk. This value will grow as database runs for longer periods of time",
 	})
-	backgroundFlushingtotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	backgroundFlushingtotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "total_milliseconds",

--- a/collector/collection_wiredtiger.go
+++ b/collector/collection_wiredtiger.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	collWTBlockManagerBlocksTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	collWTBlockManagerBlocksTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "collection_wiredtiger_blockmanager",
 		Name:      "blocks_total",
@@ -20,7 +20,7 @@ var (
 		Name:      "pages",
 		Help:      "The current number of pages in the WiredTiger Cache",
 	}, []string{"ns", "type"})
-	collWTCachePagesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	collWTCachePagesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "collection_wiredtiger_cache",
 		Name:      "pages_total",
@@ -32,13 +32,13 @@ var (
 		Name:      "bytes",
 		Help:      "The current size of data in the WiredTiger Cache in bytes",
 	}, []string{"ns", "type"})
-	collWTCacheBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	collWTCacheBytesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "collection_wiredtiger_cache",
 		Name:      "bytes_total",
 		Help:      "The total number of bytes read into/from the WiredTiger Cache",
 	}, []string{"ns", "type"})
-	collWTCacheEvictedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	collWTCacheEvictedTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "collection_wiredtiger_cache",
 		Name:      "evicted_total",

--- a/collector/conn_pool_stats.go
+++ b/collector/conn_pool_stats.go
@@ -37,7 +37,7 @@ var (
 		Help:      "Corresponds to the total number of client connections to mongo that are currently available.",
 	})
 
-	totalCreated = prometheus.NewCounter(prometheus.CounterOpts{
+	totalCreated = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "connpoolstats",
 		Name:      "connections_created_total",

--- a/collector/connections.go
+++ b/collector/connections.go
@@ -12,7 +12,7 @@ var (
 	}, []string{"state"})
 )
 var (
-	connectionsMetricsCreatedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	connectionsMetricsCreatedTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "connections_metrics",
 		Name:      "created_total",

--- a/collector/global_lock.go
+++ b/collector/global_lock.go
@@ -11,7 +11,7 @@ var (
 		Name:      "ratio",
 		Help:      "The value of ratio displays the relationship between lockTime and totalTime. Low values indicate that operations have held the globalLock frequently for shorter periods of time. High values indicate that operations have held globalLock infrequently for longer periods of time",
 	})
-	globalLockTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	globalLockTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "global_lock",
 		Name:      "total",

--- a/collector/index_counters.go
+++ b/collector/index_counters.go
@@ -14,7 +14,7 @@ var (
 )
 
 var (
-	indexCountersTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	indexCountersTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "index_counters_total",
 		Help:      "Total indexes by type",

--- a/collector/locks.go
+++ b/collector/locks.go
@@ -5,21 +5,21 @@ import (
 )
 
 var (
-	locksTimeLockedGlobalMicrosecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	locksTimeLockedGlobalMicrosecondsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "locks_time_locked_global_microseconds_total",
 		Help:      "amount of time in microseconds that any database has held the global lock",
 	}, []string{"type", "database"})
 )
 var (
-	locksTimeLockedLocalMicrosecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	locksTimeLockedLocalMicrosecondsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "locks_time_locked_local_microseconds_total",
 		Help:      "amount of time in microseconds that any database has held the local lock",
 	}, []string{"type", "database"})
 )
 var (
-	locksTimeAcquiringGlobalMicrosecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	locksTimeAcquiringGlobalMicrosecondsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "locks_time_acquiring_global_microseconds_total",
 		Help:      "amount of time in microseconds that any database has spent waiting for the global lock",

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	metricsCursorTimedOutTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsCursorTimedOutTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_cursor",
 		Name:      "timed_out_total",
@@ -20,7 +20,7 @@ var (
 	}, []string{"state"})
 )
 var (
-	metricsDocumentTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	metricsDocumentTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_document_total",
 		Help:      "The document holds a document of that reflect document access and modification patterns and data use. Compare these values to the data in the opcounters document, which track total number of operations",
@@ -33,7 +33,7 @@ var (
 		Name:      "num_total",
 		Help:      "num reports the total number of getLastError operations with a specified write concern (i.e. w) that wait for one or more members of a replica set to acknowledge the write operation (i.e. a w value greater than 1.)",
 	})
-	metricsGetLastErrorWtimeTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsGetLastErrorWtimeTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_get_last_error_wtime",
 		Name:      "total_milliseconds",
@@ -41,7 +41,7 @@ var (
 	})
 )
 var (
-	metricsGetLastErrorWtimeoutsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsGetLastErrorWtimeoutsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_get_last_error",
 		Name:      "wtimeouts_total",
@@ -49,21 +49,21 @@ var (
 	})
 )
 var (
-	metricsOperationTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	metricsOperationTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_operation_total",
 		Help:      "operation is a sub-document that holds counters for several types of update and query operations that MongoDB handles using special operation types",
 	}, []string{"type"})
 )
 var (
-	metricsQueryExecutorTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	metricsQueryExecutorTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_query_executor_total",
 		Help:      "queryExecutor is a document that reports data from the query execution system",
 	}, []string{"state"})
 )
 var (
-	metricsRecordMovesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsRecordMovesTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_record",
 		Name:      "moves_total",
@@ -71,13 +71,13 @@ var (
 	})
 )
 var (
-	metricsReplApplyBatchesNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplApplyBatchesNumTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_apply_batches",
 		Name:      "num_total",
 		Help:      "num reports the total number of batches applied across all databases",
 	})
-	metricsReplApplyBatchesTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplApplyBatchesTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_apply_batches",
 		Name:      "total_milliseconds",
@@ -85,7 +85,7 @@ var (
 	})
 )
 var (
-	metricsReplApplyOpsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplApplyOpsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_apply",
 		Name:      "ops_total",
@@ -99,7 +99,7 @@ var (
 		Name:      "count",
 		Help:      "count reports the current number of operations in the oplog buffer",
 	})
-	metricsReplBufferMaxSizeBytes = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplBufferMaxSizeBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_buffer",
 		Name:      "max_size_bytes",
@@ -113,13 +113,13 @@ var (
 	})
 )
 var (
-	metricsReplNetworkGetmoresNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkGetmoresNumTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network_getmores",
 		Name:      "num_total",
 		Help:      "num reports the total number of getmore operations, which are operations that request an additional set of operations from the replication sync source.",
 	})
-	metricsReplNetworkGetmoresTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkGetmoresTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network_getmores",
 		Name:      "total_milliseconds",
@@ -127,19 +127,19 @@ var (
 	})
 )
 var (
-	metricsReplNetworkBytesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkBytesTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network",
 		Name:      "bytes_total",
 		Help:      "bytes reports the total amount of data read from the replication sync source",
 	})
-	metricsReplNetworkOpsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkOpsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network",
 		Name:      "ops_total",
 		Help:      "ops reports the total number of operations read from the replication source.",
 	})
-	metricsReplNetworkReadersCreatedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkReadersCreatedTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network",
 		Name:      "readers_created_total",
@@ -169,13 +169,13 @@ var (
 	})
 )
 var (
-	metricsReplPreloadDocsNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplPreloadDocsNumTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_preload_docs",
 		Name:      "num_total",
 		Help:      "num reports the total number of documents loaded during the pre-fetch stage of replication",
 	})
-	metricsReplPreloadDocsTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplPreloadDocsTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_preload_docs",
 		Name:      "total_milliseconds",
@@ -183,13 +183,13 @@ var (
 	})
 )
 var (
-	metricsReplPreloadIndexesNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplPreloadIndexesNumTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_preload_indexes",
 		Name:      "num_total",
 		Help:      "num reports the total number of index entries loaded by members before updating documents as part of the pre-fetch stage of replication",
 	})
-	metricsReplPreloadIndexesTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplPreloadIndexesTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_preload_indexes",
 		Name:      "total_milliseconds",
@@ -197,20 +197,20 @@ var (
 	})
 )
 var (
-	metricsStorageFreelistSearchTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	metricsStorageFreelistSearchTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_storage_freelist_search_total",
 		Help:      "metrics about searching records in the database.",
 	}, []string{"type"})
 )
 var (
-	metricsTTLDeletedDocumentsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsTTLDeletedDocumentsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_ttl",
 		Name:      "deleted_documents_total",
 		Help:      "deletedDocuments reports the total number of documents deleted from collections with a ttl index.",
 	})
-	metricsTTLPassesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsTTLPassesTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_ttl",
 		Name:      "passes_total",

--- a/collector/network.go
+++ b/collector/network.go
@@ -5,14 +5,14 @@ import (
 )
 
 var (
-	networkBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	networkBytesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "network_bytes_total",
 		Help:      "The network data structure contains data regarding MongoDB's network use",
 	}, []string{"state"})
 )
 var (
-	networkMetricsNumRequestsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	networkMetricsNumRequestsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "network_metrics",
 		Name:      "num_requests_total",

--- a/collector/op_counters.go
+++ b/collector/op_counters.go
@@ -5,14 +5,14 @@ import (
 )
 
 var (
-	opCountersTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	opCountersTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_counters_total",
 		Help:      "The opcounters data structure provides an overview of database operations by type and makes it possible to analyze the load on the database in more granular manner. These numbers will grow over time and in response to database use. Analyze these values over time to track database utilization",
 	}, []string{"type"})
 )
 var (
-	opCountersReplTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	opCountersReplTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_counters_repl_total",
 		Help:      "The opcountersRepl data structure, similar to the opcounters data structure, provides an overview of database replication operations by type and makes it possible to analyze the load on the replica in more granular manner. These values only appear when the current host has replication enabled",

--- a/collector/replset_status.go
+++ b/collector/replset_status.go
@@ -63,7 +63,7 @@ var (
 		Name:      "member_state",
 		Help:      "The value of state is an integer between 0 and 10 that represents the replica state of the member.",
 	}, []string{"set", "name"})
-	memberUptime = prometheus.NewCounterVec(prometheus.CounterOpts{
+	memberUptime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_uptime",

--- a/collector/server_status.go
+++ b/collector/server_status.go
@@ -10,19 +10,19 @@ import (
 )
 
 var (
-	instanceUptimeSeconds = prometheus.NewCounter(prometheus.CounterOpts{
+	instanceUptimeSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "instance",
 		Name:      "uptime_seconds",
 		Help:      "The value of the uptime field corresponds to the number of seconds that the mongos or mongod process has been active.",
 	})
-	instanceUptimeEstimateSeconds = prometheus.NewCounter(prometheus.CounterOpts{
+	instanceUptimeEstimateSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "instance",
 		Name:      "uptime_estimate_seconds",
 		Help:      "uptimeEstimate provides the uptime as calculated from MongoDB's internal course-grained time keeping system.",
 	})
-	instanceLocalTime = prometheus.NewCounter(prometheus.CounterOpts{
+	instanceLocalTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "instance",
 		Name:      "local_time",
@@ -106,7 +106,7 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 		status.OpcountersRepl.Export(ch)
 	}
 	if status.TCMallocStats != nil {
-	    status.TCMallocStats.Export(ch)
+		status.TCMallocStats.Export(ch)
 	}
 	if status.Mem != nil {
 		status.Mem.Export(ch)
@@ -173,7 +173,7 @@ func (status *ServerStatus) Describe(ch chan<- *prometheus.Desc) {
 		status.OpcountersRepl.Describe(ch)
 	}
 	if status.TCMallocStats != nil {
-	    status.TCMallocStats.Describe(ch)
+		status.TCMallocStats.Describe(ch)
 	}
 	if status.Mem != nil {
 		status.Mem.Describe(ch)

--- a/collector/storage_engine.go
+++ b/collector/storage_engine.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	storageEngine = prometheus.NewCounterVec(prometheus.CounterOpts{
+	storageEngine = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "storage_engine",
 		Help:      "The storage engine used by the MongoDB instance",

--- a/collector/tcmalloc.go
+++ b/collector/tcmalloc.go
@@ -27,13 +27,13 @@ var (
 		Help:      "Sizes for tcpmalloc caches in bytes",
 	}, []string{"cache", "type"})
 
-	tcmallocAggressiveDecommit = prometheus.NewCounter(prometheus.CounterOpts{
+	tcmallocAggressiveDecommit = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "tcmalloc_aggressive_memory_decommit",
 		Help:      "Whether aggressive_memory_decommit is on",
 	})
 
-	tcmallocFreeBytes = prometheus.NewCounter(prometheus.CounterOpts{
+	tcmallocFreeBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "tcmalloc_free_bytes",
 		Help:      "Total free bytes of tcmalloc",

--- a/collector/top_counters.go
+++ b/collector/top_counters.go
@@ -8,12 +8,12 @@ import (
 )
 
 var (
-	topTimeSecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	topTimeSecondsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "top_time_seconds_total",
 		Help:      "The top command provides operation time, in seconds, for each database collection",
 	}, []string{"type", "database", "collection"})
-	topCountTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	topCountTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "top_count_total",
 		Help:      "The top command provides operation count for each database collection",

--- a/collector/wiredtiger.go
+++ b/collector/wiredtiger.go
@@ -19,13 +19,13 @@ import (
 )
 
 var (
-	wtBlockManagerBlocksTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtBlockManagerBlocksTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_blockmanager",
 		Name:      "blocks_total",
 		Help:      "The total number of blocks read by the WiredTiger BlockManager",
 	}, []string{"type"})
-	wtBlockManagerBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtBlockManagerBytesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_blockmanager",
 		Name:      "bytes_total",
@@ -40,7 +40,7 @@ var (
 		Name:      "pages",
 		Help:      "The current number of pages in the WiredTiger Cache",
 	}, []string{"type"})
-	wtCachePagesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtCachePagesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "pages_total",
@@ -58,13 +58,13 @@ var (
 		Name:      "max_bytes",
 		Help:      "The maximum size of data in the WiredTiger Cache in bytes",
 	})
-	wtCacheBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtCacheBytesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "bytes_total",
 		Help:      "The total number of bytes read into/from the WiredTiger Cache",
 	}, []string{"type"})
-	wtCacheEvictedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtCacheEvictedTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "evicted_total",
@@ -79,13 +79,13 @@ var (
 )
 
 var (
-	wtTransactionsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtTransactionsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_transactions",
 		Name:      "total",
 		Help:      "The total number of transactions WiredTiger has handled",
 	}, []string{"type"})
-	wtTransactionsTotalCheckpointMs = prometheus.NewCounter(prometheus.CounterOpts{
+	wtTransactionsTotalCheckpointMs = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_transactions",
 		Name:      "checkpoint_milliseconds_total",
@@ -106,25 +106,25 @@ var (
 )
 
 var (
-	wtLogRecordsScannedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	wtLogRecordsScannedTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_log",
 		Name:      "records_scanned_total",
 		Help:      "The total number of records scanned by log scan in the WiredTiger log",
 	})
-	wtLogRecordsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtLogRecordsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_log",
 		Name:      "records_total",
 		Help:      "The total number of compressed/uncompressed records written to the WiredTiger log",
 	}, []string{"type"})
-	wtLogBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtLogBytesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_log",
 		Name:      "bytes_total",
 		Help:      "The total number of bytes written to the WiredTiger log",
 	}, []string{"type"})
-	wtLogOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtLogOperationsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_log",
 		Name:      "operations_total",

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2daa265ce1037e5ac801ef074714e212b1ff69f2fea2e5c69a6c05ece9326f31
-updated: 2018-03-15T17:01:48.086832728-07:00
+hash: e0d331e004b8fd0b7e2b044a30b1f95c8bf1a0006badf93ae6d8af74f6869704
+updated: 2018-08-05T14:18:53.309129007-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -16,7 +16,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
+  version: 967789050ba94deca04a5e84cce8ad472ce313c1
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/dcu/mongodb_exporter
 import:
 - package: github.com/golang/glog
 - package: github.com/prometheus/client_golang
-  version: v0.8.0
+  version: v0.9.0-pre1
   subpackages:
   - prometheus
 - package: gopkg.in/mgo.v2


### PR DESCRIPTION
The latest version of Prometheus client does not allow to ".Set" a value on a
Counter. In fact, in the version of the library that this exporter is using,
there is a note for deprecation on that method.

This patch basically convert to Gauges all the Counters whose values are set by
the no longer existing method. This way we avoid errors such us:
```
collector/wiredtiger.go:218:43: wtCacheBytesTotal.WithLabelValues("read").Set undefined (type prometheus.Counter has no field or method Set)
collector/wiredtiger.go:219:46: wtCacheBytesTotal.WithLabelValues("written").Set undefined (type prometheus.Counter has no field or method Set)
collector/wiredtiger.go:272:26: wtLogRecordsScannedTotal.Set undefined (type prometheus.Counter has no field or method Set)
```