### PR TITLE
A fix of labels for wiredtiger_concurrent_transactions_out_tickets

### DIFF
--- a/collector/wiredtiger.go
+++ b/collector/wiredtiger.go
@@ -335,8 +335,8 @@ type WTConcurrentTransactionsTypeStats struct {
 }
 
 type WTConcurrentTransactionsStats struct {
-	Write *WTConcurrentTransactionsTypeStats `bson:"read"`
-	Read  *WTConcurrentTransactionsTypeStats `bson:"write"`
+	Read  *WTConcurrentTransactionsTypeStats `bson:"read"`
+	Write *WTConcurrentTransactionsTypeStats `bson:"write"`
 }
 
 func (stats *WTConcurrentTransactionsStats) Export(ch chan<- prometheus.Metric) {


### PR DESCRIPTION
Found by @akira-kurogane at https://github.com/percona/mongodb_exporter/pull/118.