### PR TITLE
Fix builds and update alpine image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM       golang:alpine as builder
+FROM       golang:1.14-alpine as builder
 
 RUN apk --no-cache add curl git make perl
 RUN curl -s https://glide.sh/get | sh
 COPY . /go/src/github.com/dcu/mongodb_exporter
 RUN cd /go/src/github.com/dcu/mongodb_exporter && make release
 
-FROM       alpine:3.4
+FROM       alpine:3.11
 MAINTAINER David Cuadrado <dacuad@facebook.com>
 EXPOSE     9001
 


### PR DESCRIPTION
Currently doesn't build with the image tag for golang as it is. Instead use `golang:1.14-alpine`

Also updates the `alpine` image to `3.11` (the latest as of writing this).