### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM       golang:alpine as builder
+FROM golang:alpine as builder
 
-RUN apk --no-cache add curl git make perl
-RUN curl -s https://glide.sh/get | sh
+RUN apk --no-cache add curl git make perl unzip
+RUN wget "https://github.com/Masterminds/glide/releases/download/v0.13.3/glide-v0.13.3-linux-amd64.zip" && \
+    unzip glide-v0.13.3-linux-amd64.zip && \
+    mv linux-amd64/glide /usr/bin
 COPY . /go/src/github.com/dcu/mongodb_exporter
+RUN go env -w GO111MODULE=off
 RUN cd /go/src/github.com/dcu/mongodb_exporter && make release
 
 FROM       alpine:3.4
-MAINTAINER David Cuadrado <dacuad@facebook.com>
 EXPOSE     9001
 
 RUN apk add --update ca-certificates


### PR DESCRIPTION
fix build issue. Remove bad build script from glide
The domain is expired and the script link is not working so I replaced it and used pre-built binary